### PR TITLE
Fix NSG name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,6 @@ resource "azurerm_network_security_rule" "rule" {
 
 
         resource_group_name          = var.resource_group_name
-        network_security_group_name  = var.network_security_group_names
+        network_security_group_name  = basename(var.network_security_group_name)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "rules" {
   }))
 }
 
-variable "network_security_group_names" {
+variable "network_security_group_name" {
   description = "nsg names ti which the rule will be associated"
   type        = string
   default     = ""


### PR DESCRIPTION
This PR does 2 things:
- change `network_security_group_names` to `network_security_group_name`
- extract basename of `network_security_group_name` in case the ID is provided instead of the name